### PR TITLE
setPlaybackTime

### DIFF
--- a/music_kit/android/build.gradle
+++ b/music_kit/android/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlinx-serialization'
 
 android {
+    namespace 'app.misi.music_kit'
     compileSdkVersion 31
 
     compileOptions {

--- a/music_kit/android/src/main/kotlin/app/misi/music_kit/ChannelHandler.kt
+++ b/music_kit/android/src/main/kotlin/app/misi/music_kit/ChannelHandler.kt
@@ -270,6 +270,12 @@ class ChannelHandler(
 
   @Keep
   @Suppress("unused", "UNUSED_PARAMETER")
+  fun setPlaybackTime(call: MethodCall, result: MethodChannel.Result) {
+    result.notImplemented()
+  }
+
+  @Keep
+  @Suppress("unused", "UNUSED_PARAMETER")
   fun musicPlayerState(call: MethodCall, result: MethodChannel.Result) {
     val state = mapOf<String, Any>(
       "playbackStatus" to (playerController?.playbackState ?: PlaybackState.STOPPED),

--- a/music_kit/ios/Classes/MusicKitApplicationPlayer.swift
+++ b/music_kit/ios/Classes/MusicKitApplicationPlayer.swift
@@ -115,7 +115,10 @@ fileprivate func parseMusicItem(_ itemType: String, from itemObject: ResourceObj
 
 extension ApplicationMusicPlayer {
   func setQueue(item: PlayableMusicItem) {
-    queue = [item]
+    // startTime not working
+    // https://developer.apple.com/forums/thread/714807
+    let entry = MusicPlayer.Queue.Entry(item)
+    queue = ApplicationMusicPlayer.Queue([entry])
   }
   
   func setQueue<MusicItemType: PlayableMusicItem>(items: MusicItemCollection<MusicItemType>) {

--- a/music_kit/ios/Classes/MusicKitPluginMethodKeys.swift
+++ b/music_kit/ios/Classes/MusicKitPluginMethodKeys.swift
@@ -19,6 +19,7 @@ extension SwiftMusicKitPlugin {
     // player
     case isPreparedToPlay
     case playbackTime
+    case setPlaybackTime
     case musicPlayerState
     case pause
     case play

--- a/music_kit/ios/Classes/MusicKitPluginPlayer.swift
+++ b/music_kit/ios/Classes/MusicKitPluginPlayer.swift
@@ -22,6 +22,11 @@ extension SwiftMusicKitPlugin {
   func playbackTime(_ result: @escaping FlutterResult) {
     result(musicPlayer.playbackTime)
   }
+
+  func setPlaybackTime(_ time: Double, result: @escaping FlutterResult) {
+    musicPlayer.playbackTime = TimeInterval(time)
+    result(nil)
+  }
   
   func musicPlayerState(_ result: @escaping FlutterResult) {
     result(musicPlayer.state.jsonObject())

--- a/music_kit/ios/Classes/MusicKitPluginSubscription.swift
+++ b/music_kit/ios/Classes/MusicKitPluginSubscription.swift
@@ -17,7 +17,9 @@ extension SwiftMusicKitPlugin {
       
       updatesTask = Task {
         for await subscription in MusicSubscription.subscriptionUpdates {
-          eventSink?(subscription.jsonObject())
+          DispatchQueue.main.async { [weak self] in
+            self?.eventSink?(subscription.jsonObject())
+          }
         }
       }
       

--- a/music_kit/ios/Classes/SwiftMusicKitPlugin.swift
+++ b/music_kit/ios/Classes/SwiftMusicKitPlugin.swift
@@ -48,6 +48,9 @@ public class SwiftMusicKitPlugin: NSObject, FlutterPlugin {
       
     case .playbackTime:
       playbackTime(result)
+
+    case .setPlaybackTime:
+      setPlaybackTime(call.arguments as! Double, result: result)
       
     case .musicPlayerState:
       musicPlayerState(result)

--- a/music_kit/lib/music_kit.dart
+++ b/music_kit/lib/music_kit.dart
@@ -49,6 +49,8 @@ class MusicKit {
 
   Future<double> get playbackTime => _platform.playbackTime;
 
+  Future<void> setPlaybackTime(double time) => _platform.setPlaybackTime(time);
+
   Future<MusicPlayerState> get musicPlayerState => _platform.musicPlayerState;
 
   Stream<MusicPlayerState> get onMusicPlayerStateChanged =>

--- a/music_kit/pubspec.yaml
+++ b/music_kit/pubspec.yaml
@@ -12,6 +12,10 @@ dependencies:
     sdk: flutter
   music_kit_platform_interface: ^1.1.0
 
+dependency_overrides:
+  music_kit_platform_interface:
+    path: ../music_kit_platform_interface
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/music_kit_platform_interface/lib/method_channel/method_channel_music_kit.dart
+++ b/music_kit_platform_interface/lib/method_channel/method_channel_music_kit.dart
@@ -99,6 +99,11 @@ class MethodChannelMusicKit extends MusicKitPlatform {
   }
 
   @override
+  Future<void> setPlaybackTime(double time) {
+    return methodChannel.invokeMethod('setPlaybackTime', time);
+  }
+
+  @override
   Future<MusicPlayerState> get musicPlayerState async {
     final resp = await methodChannel
         .invokeMapMethod<String, dynamic>('musicPlayerState');

--- a/music_kit_platform_interface/lib/music_kit_platform_interface.dart
+++ b/music_kit_platform_interface/lib/music_kit_platform_interface.dart
@@ -73,6 +73,10 @@ abstract class MusicKitPlatform extends PlatformInterface {
     throw UnimplementedError('get playbackTime has not been implemented.');
   }
 
+  Future<void> setPlaybackTime(double time) async {
+    throw UnimplementedError('setPlaybackTime() has not been implemented.');
+  }
+
   Future<MusicPlayerState> get musicPlayerState async {
     throw UnimplementedError('get musicPlayerState has not been implemented.');
   }


### PR DESCRIPTION
I added setPlaybackTime for playing not from the beginning, this can be done for example between prepareToPlay and play

also fixed a warning on MusicSubscription result not being sent on the main thread

apple api supports setting start/end times in MusicPlayer.Queue.Entry but there's an apple bug preventing it from working: https://developer.apple.com/forums/thread/714807
I left a stub for that in setQueue(item: PlayableMusicItem) for the future when it could be implemented