### PR TITLE
feat(android)!: Android implementation now behaves more like the IOS implementation

### DIFF
--- a/packages/music_kit/README.md
+++ b/packages/music_kit/README.md
@@ -26,8 +26,18 @@ repositories {
 }
 ```
 
-2. Call `initialize(developerToken, musicUserToken: [userToken])` method manually
-   before using the MusicKit instance.
+2. Add your apple developer teamId, keyId and base64-encoded key to your `AndroidManifest.xml`
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+      ...
+       <meta-data android:name="music_kit.teamId" android:value="<TEAM_ID>" />
+       <meta-data android:name="music_kit.keyId"  android:value="<KEY_ID>" />
+       <meta-data android:name="music_kit.key"    android:value="<BASE64_ENCODED_KEY>" />
+    </application>
+</manifest>
+```
 
 ### Example
 

--- a/packages/music_kit/android/build.gradle
+++ b/packages/music_kit/android/build.gradle
@@ -58,6 +58,10 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.1.0'
+
+        implementation "io.jsonwebtoken:jjwt-api:0.12.6"
+        runtimeOnly "io.jsonwebtoken:jjwt-impl:0.12.6"
+        runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.12.6"
     }
 
     testOptions {

--- a/packages/music_kit/android/src/main/kotlin/app/misi/music_kit/PlayerQueueStreamHandler.kt
+++ b/packages/music_kit/android/src/main/kotlin/app/misi/music_kit/PlayerQueueStreamHandler.kt
@@ -9,7 +9,7 @@ import com.apple.android.music.playback.model.PlayerMediaItem
 import com.apple.android.music.playback.model.PlayerQueueItem
 import io.flutter.plugin.common.EventChannel
 
-class PlayerQueueStreamHandler(private val playerController: MediaPlayerController?) :
+class PlayerQueueStreamHandler() :
   EventChannel.StreamHandler {
   companion object {
     fun convertQueueItem(it: PlayerQueueItem): Map<String, Any?> {
@@ -25,15 +25,21 @@ class PlayerQueueStreamHandler(private val playerController: MediaPlayerControll
   private var eventSink: EventChannel.EventSink? = null
   private var entries: List<Map<String, Any?>> = listOf()
   private var currentEntry: Map<String, Any?>? = null
+  private var playerController: MediaPlayerController? = null
+
+  fun setPlayerController(controller: MediaPlayerController) {
+    playerController?.removeListener(playerControllerListener)
+    controller.addListener(playerControllerListener)
+    playerController = controller
+  }
+
 
   override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
     eventSink = events
-    playerController?.addListener(playerControllerListener)
   }
 
   override fun onCancel(arguments: Any?) {
     eventSink = null
-    playerController?.removeListener(playerControllerListener)
   }
 
   private val playerControllerListener = object : MediaPlayerController.Listener {
@@ -93,7 +99,7 @@ class PlayerQueueStreamHandler(private val playerController: MediaPlayerControll
     }
 
     override fun onPlaybackError(p0: MediaPlayerController, p1: MediaPlayerException) {
-      Log.d(LOG_TAG, "Queue Handler onPlaybackError() error(${p1.errorCode}): ${p1.message}")
+      Log.d(LOG_TAG, "Queue Handler TEST onPlaybackError() error(${p1.errorCode}): ${p1.message}", p1)
     }
 
     override fun onPlaybackRepeatModeChanged(p0: MediaPlayerController, p1: Int) {

--- a/packages/music_kit/android/src/main/kotlin/app/misi/music_kit/infrastructure/MusicApiImpl.kt
+++ b/packages/music_kit/android/src/main/kotlin/app/misi/music_kit/infrastructure/MusicApiImpl.kt
@@ -3,6 +3,7 @@ package app.misi.music_kit.infrastructure
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
 
 class MusicApiImpl(
@@ -14,13 +15,17 @@ class MusicApiImpl(
   }
 
   override suspend fun getStorefrontId(developerToken: String, musicUserToken: String): String {
-    val storefronts = client.get(USER_STOREFRONT) {
+    val response = client.get(USER_STOREFRONT) {
       headers {
         append(HttpHeaders.Authorization, "Bearer $developerToken")
         append("Music-User-Token", musicUserToken)
       }
-    }.body<Storefronts>()
+    }
+    if (response.status.isSuccess()) {
+      val storefronts = response.body<Storefronts>()
 
-    return storefronts.data.first().id
+      return storefronts.data.first().id
+    }
+    throw RuntimeException("Could not get user storefront: ${response.bodyAsText()}")
   }
 }

--- a/packages/music_kit/android/src/main/kotlin/app/misi/music_kit/util/AppleDeveloperToken.kt
+++ b/packages/music_kit/android/src/main/kotlin/app/misi/music_kit/util/AppleDeveloperToken.kt
@@ -1,0 +1,33 @@
+package app.misi.music_kit.util
+
+import android.util.Base64
+import io.jsonwebtoken.Jwts
+import java.security.KeyFactory
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Date
+
+class AppleDeveloperToken(private val key: String, private val keyId: String, private val teamId: String) {
+
+    private companion object {
+        fun generateToken(privateKey: String, keyId: String, teamId: String): String {
+            val appleKey = KeyFactory.getInstance("EC")
+                .generatePrivate(PKCS8EncodedKeySpec(Base64.decode(privateKey, Base64.DEFAULT)))
+            val now = Date()
+
+            val jwt = Jwts.builder().apply {
+                header().add("alg", "ES256").add("kid", keyId)
+                claim("iss", teamId)
+                issuedAt(now)
+                expiration(Date(now.time + 150L * 24 * 1000 * 60 * 60)) // exp = 150 days, can be up to 6 month
+            }.signWith(appleKey, Jwts.SIG.ES256).compact()
+
+            return jwt
+        }
+    }
+
+    private val token: String = Companion.generateToken(key, keyId, teamId);
+
+    override fun toString(): String {
+        return token
+    }
+}

--- a/packages/music_kit/example/lib/main.dart
+++ b/packages/music_kit/example/lib/main.dart
@@ -72,10 +72,10 @@ class _MyAppState extends State<MyApp> {
     final status = await _musicKitPlugin.authorizationStatus;
 
     switch (status) {
-      case MusicAuthorizationStatusInitial() ||
-            MusicAuthorizationStatusDenied() ||
+      case MusicAuthorizationStatusDenied() ||
             MusicAuthorizationStatusNotDetermined() ||
-            MusicAuthorizationStatusRestricted():
+            MusicAuthorizationStatusRestricted() ||
+            MusicAuthorizationStatusExpired:
         return;
       case MusicAuthorizationStatusAuthorized():
         {}

--- a/packages/music_kit/lib/music_kit.dart
+++ b/packages/music_kit/lib/music_kit.dart
@@ -4,11 +4,11 @@ export 'package:music_kit_platform_interface/music_kit_platform_interface.dart'
     show
         //
         MusicAuthorizationStatus,
-        MusicAuthorizationStatusInitial,
         MusicAuthorizationStatusAuthorized,
         MusicAuthorizationStatusDenied,
         MusicAuthorizationStatusNotDetermined,
         MusicAuthorizationStatusRestricted,
+        MusicAuthorizationStatusExpired,
         //
         MusicSubscription,
         //
@@ -32,9 +32,6 @@ class MusicKit {
   static MusicKitPlatform get _platform {
     return MusicKitPlatform.instance;
   }
-
-  Future<void> initialize(String developerToken, {String? musicUserToken}) =>
-      _platform.initialize(developerToken, musicUserToken: musicUserToken);
 
   Future<MusicAuthorizationStatus> requestAuthorizationStatus({String? startScreenMessage}) =>
       _platform.requestAuthorizationStatus(startScreenMessage: startScreenMessage);

--- a/packages/music_kit_darwin/darwin/music_kit_darwin/Sources/music_kit_darwin/MusicKitPlugin.swift
+++ b/packages/music_kit_darwin/darwin/music_kit_darwin/Sources/music_kit_darwin/MusicKitPlugin.swift
@@ -50,9 +50,6 @@ public class MusicKitPlugin: NSObject, FlutterPlugin {
     }
     
     switch methodKey {
-    case .initialize:
-        result(nil)
-        
     case .authorizationStatus:
       authorizationStatus(result)
         

--- a/packages/music_kit_darwin/darwin/music_kit_darwin/Sources/music_kit_darwin/MusicKitPluginMethodKeys.swift
+++ b/packages/music_kit_darwin/darwin/music_kit_darwin/Sources/music_kit_darwin/MusicKitPluginMethodKeys.swift
@@ -9,7 +9,6 @@ import Foundation
 
 extension MusicKitPlugin {
   enum MethodKeys: String {
-    case initialize
     case authorizationStatus
     case requestAuthorizationStatus
     //

--- a/packages/music_kit_platform_interface/lib/src/method_channel/method_channel_music_kit.dart
+++ b/packages/music_kit_platform_interface/lib/src/method_channel/method_channel_music_kit.dart
@@ -17,14 +17,6 @@ class MethodChannelMusicKit extends MusicKitPlatform {
   final musicSubcriptionEventChannel = const EventChannel('plugins.misi.app/music_kit/music_subscription');
 
   @override
-  Future<void> initialize(String developerToken, {String? musicUserToken}) async {
-    return methodChannel.invokeMethod(
-      'initialize',
-      {'developerToken': developerToken, 'musicUserToken': musicUserToken},
-    );
-  }
-
-  @override
   Future<MusicAuthorizationStatus> requestAuthorizationStatus({String? startScreenMessage}) async {
     try {
       final resp = await methodChannel
@@ -240,7 +232,9 @@ MusicAuthorizationStatus _authorizationStatusfromRawValue(int rawValue, {String?
       return MusicAuthorizationStatusNotDetermined();
     case 3:
       return MusicAuthorizationStatusRestricted();
+    case 4:
+      return MusicAuthorizationStatusExpired();
     default:
-      return MusicAuthorizationStatusInitial();
+      return MusicAuthorizationStatusNotDetermined();
   }
 }

--- a/packages/music_kit_platform_interface/lib/src/platform_interface/music_kit_platform.dart
+++ b/packages/music_kit_platform_interface/lib/src/platform_interface/music_kit_platform.dart
@@ -17,10 +17,6 @@ abstract class MusicKitPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<void> initialize(String developerToken, {String? musicUserToken}) async {
-    throw UnimplementedError('initialize() has not been implemented.');
-  }
-
   Future<MusicAuthorizationStatus> requestAuthorizationStatus({String? startScreenMessage}) async {
     throw UnimplementedError('requestAuthorizationStatus() has not been implemented.');
   }

--- a/packages/music_kit_platform_interface/lib/src/types/music_authorization_status.dart
+++ b/packages/music_kit_platform_interface/lib/src/types/music_authorization_status.dart
@@ -1,7 +1,5 @@
 sealed class MusicAuthorizationStatus {}
 
-class MusicAuthorizationStatusInitial extends MusicAuthorizationStatus {}
-
 class MusicAuthorizationStatusAuthorized extends MusicAuthorizationStatus {
   final String? musicUserToken;
 
@@ -13,3 +11,5 @@ class MusicAuthorizationStatusDenied extends MusicAuthorizationStatus {}
 class MusicAuthorizationStatusNotDetermined extends MusicAuthorizationStatus {}
 
 class MusicAuthorizationStatusRestricted extends MusicAuthorizationStatus {}
+
+class MusicAuthorizationStatusExpired extends MusicAuthorizationStatus {}


### PR DESCRIPTION
- initialize is no longer required as developer and music user tokens are now managed internally
  - developer token is automatically generated from keyId, teamId and key (provided in application meta-data in AndroidManifest.xml)
  - music user token is stored in and retrieved from SharedPreferences
  - music user token is tested for expiration by retrieving the user's storefront after retrieval
- ChannelHandler: storefront is no longer nullable as IOS also returns a blank string if storefront is not known
- ChannelHandler: authorizationStatus now returns MusicAuthorizationStatusExpired if music user token has expired
- refactor PlayerStateStreamHandler and PlayerQueueStreamHandler to allow setting PlayerController if (re-)initialized
- add util/AppleDeveloperToken.kt for generating developer token

BREAKING CHANGE: removed MusicAuthorizationStatusInitial, add MusicAuthorizationStatusExpired, remove initialize(String developerToken, {String? musicUserToken})